### PR TITLE
Added a similar method and updated getindex to preserve tuplevector state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TupleVectors"
 uuid = "615932cf-77b6-4358-adcd-5b7eba981d7e"
 authors = ["Chad Scherrer <chad.scherrer@gmail.com> and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"

--- a/src/optional/Sobol.jl
+++ b/src/optional/Sobol.jl
@@ -1,4 +1,4 @@
-using Sobol: SobolSeq
+using .Sobol: SobolSeq
 import .Sobol
 using ..TupleVectors
 

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -96,8 +96,6 @@ function Base.getindex(x::TupleVector, j::Integer)
     modify(f, unwrap(x), Leaves())
 end
 
-
-
 function Base.setindex!(a::TupleVector, x, j::Integer)
     a1 = flatten(unwrap(a))
     x1 = flatten(x)

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -101,7 +101,7 @@ end
 
 
 
-function Base.setindex!(a::TupleVector, x, j::Int)
+function Base.setindex!(a::TupleVector, x, j::Integer)
     a1 = flatten(unwrap(a))
     x1 = flatten(x)
 

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -30,8 +30,6 @@ function Base.similar(a::TupleVector, ::Type{T}, dims::Dims) where {T}
     return TupleVector(sim)
 end
 
-
-
 function TupleVector(::UndefInitializer, x::T, n::Int) where {T<:NamedTuple}
 
     function initialize(n::Int)

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -99,16 +99,7 @@ function Base.getindex(x::TupleVector, j::Int)
     modify(f, unwrap(x), Leaves())
 end
 
-function Base.getindex(x::TupleVector, j...)
 
-    # TODO: Bounds checking doesn't affect performance, am I doing it right?
-    function f(arr)
-        # @boundscheck all(j .∈ axes(arr))
-        return @inbounds arr[j...]
-    end
-
-    TupleVector(modify(f, unwrap(x), Leaves()))
-end
 
 function Base.setindex!(a::TupleVector, x, j::Int)
     a1 = flatten(unwrap(a))

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -88,7 +88,7 @@ function Base.show(io::IO, ::MIME"text/plain", v::Vector{TV}) where {TV <: Tuple
     foreach(v) do tv println(io, summarize(tv)) end
 end
 
-function Base.getindex(x::TupleVector, j::Int)
+function Base.getindex(x::TupleVector, j::Integer)
 
     # TODO: Bounds checking doesn't affect performance, am I doing it right?
     function f(arr)

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -113,8 +113,6 @@ function Base.size(tv::TupleVector)
 end
 
 
-
-
 # TODO: Make this pass @code_warntype
 Base.getproperty(tv::TupleVector, k::Symbol) = maybewrap(getproperty(unwrap(tv), k))
 

--- a/src/tuplevector.jl
+++ b/src/tuplevector.jl
@@ -23,7 +23,6 @@ function TupleVector(a::AbstractVector{T}) where {T}
     return x
 end
 
-
 function Base.similar(a::TupleVector, ::Type{T}, dims::Dims) where {T}
     data = unwrap(a)
     sim = rmap(x->similar(x, dims), data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,11 @@ using LinearAlgebra
     nt = (w=w, y=y)
     A = TupleVector(nt)
     B = TupleVector(; w=w, y=y)
+    C = similar(B)
+    @test typeof(C) <: TupleVector
+    @test typeof(C[1:3]) <: TupleVector
     @test A.w == B.w
-    
+
     @test chainvec(3,5)[1] == 3
 
 


### PR DESCRIPTION
Hi,

This is a pretty small pull request. I have been using TupleVectors in a bunch of my personal work and I noticed that using similar, and taking slices of the array was creating a tuple of vectors or a vector of named tuples. To fix this I added a similar method, and a new getindex method that preserves the tuple state.

Old behavior:
```julia
tv = TupleVector(a=rand(10), b=rand(10))
 
similar(tv, 5)
# before pull-request:
# 10-element Vector{NamedTuple{(:u, :z), Tuple{Float64, Float64}}}:
# ...

# after pull-request returns:
# 10-element TupleVector with schema (a = Float64, b = Float64)

tv[1:5]
# before pull-request:
# (a = ...., b= ...)

# after pull-request
# 5-element TupleVector with schema (a = Float64, b = Float64)

```

I added two tests to check that slices and similar do return  TupleVectors. Hopefully, this is useful!